### PR TITLE
remove the print in the middle of the console, in case of fbterm + tmux

### DIFF
--- a/main.c
+++ b/main.c
@@ -39,7 +39,7 @@ void setup_console(int t)
 	}
 	else
 	{
-		printf("restore console\n");
+      //printf("restore console\n");
 		tcsetattr(0, TCSANOW, &old_termios);
 	}
 }


### PR DESCRIPTION
![2015-10-04 14 02 23](https://cloud.githubusercontent.com/assets/3949379/10266655/9c4a8204-6aa0-11e5-9956-663977e29f09.png)
