### PR TITLE
Compatibility with libpng 1.5+

### DIFF
--- a/png.c
+++ b/png.c
@@ -53,7 +53,7 @@ int fh_png_load(char *name, unsigned char *buffer, unsigned char ** alpha,int x,
 		return(FH_ERROR_FORMAT);
 	}
 	rp = 0;
-	if (setjmp(png_ptr->jmpbuf))
+	if (setjmp(png_jmpbuf(png_ptr)))
 	{
 		png_destroy_read_struct(&png_ptr, &info_ptr, (png_infopp)NULL);
 		if(rp) free(rp);
@@ -146,7 +146,7 @@ int fh_png_getsize(char *name, int *x, int *y)
 		return(FH_ERROR_FORMAT);
 	}
 	rp = 0;
-	if (setjmp(png_ptr->jmpbuf))
+	if (setjmp(png_jmpbuf(png_ptr)))
 	{
 		png_destroy_read_struct(&png_ptr, &info_ptr, (png_infopp)NULL);
 		if(rp) free(rp);


### PR DESCRIPTION
A change to allow fbv to compile out-of-the-box with libpng 1.5.x and 1.6.x (which don't allow direct access to the png_struct structure's members).  It also works in libpng 1.2.x, so there are no backwards-compatibility problems with the change.
