### PR TITLE
show help while running, redisplay image when the terminal is switched in

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ include Make.conf
 CC = g++ 
 CFLAGS = -Wall -D_GNU_SOURCE
 
-SOURCES	= main.c jpeg.c png.c bmp.c fb_display.c transforms.c
+SOURCES	= main.c jpeg.c png.c bmp.c fb_display.c vt.c transforms.c
 OBJECTS	= ${SOURCES:.c=.o}
 
 OUT	= fbv

--- a/fbv.1
+++ b/fbv.1
@@ -49,10 +49,25 @@ If fitting the image to the screen, fit vertically only
 .BR \fB--delay\fP , "\fB-s\fP \fI<delay>\fP"
 Slideshow, wait 'delay' tenths of a second before displaying each image
 
-.BR
-      Use a,d,w and x to scroll the image
-      
-
+.SH KEYS
+.TS
+l l.
+Key	Function
+_
+r	Redraw the image
+< or ,	Previous image
+> or .	Next image
+a, d, w, x	Scroll the image (cursor keys also do that)
+f	Toggle shrinking on/off
+k	Toggle shrinking quality
+e	Toggle enlarging on/off
+l	Toggle fitting the image horizontally
+t	Toggle fitting the image vertically
+i	Toggle respecting the image aspect on/off
+n	Rotate the image 90 degrees left
+m	Rotate the image 90 degrees right
+p	Disable all transformations
+.TE
 
 .SH AUTHOR
 Tomasz 'smoku' Sterna  <tomek@smoczy.net>

--- a/fbv.1
+++ b/fbv.1
@@ -67,6 +67,7 @@ i	Toggle respecting the image aspect on/off
 n	Rotate the image 90 degrees left
 m	Rotate the image 90 degrees right
 p	Disable all transformations
+h	Help and image information
 .TE
 
 .SH AUTHOR

--- a/fbv.1
+++ b/fbv.1
@@ -40,6 +40,9 @@ Shrink (using simple resize) the image to fit onto screen if necessary
 .BR \fB--colorshrink\fP , \fB-k\fP
 Shrink (using color average resize) the image to fit onto screen if necessary 
 .TP
+.BR \fB--enlarge\fP , \fB-e\fP
+Enlarge the image to fit the whole screen if necessary
+.TP
 .BR \fB--widthonly\fP , \fB-l\fP
 If fitting the image to the screen, fit horizontally only
 .TP

--- a/fbv.h
+++ b/fbv.h
@@ -10,6 +10,7 @@ int fb_display(unsigned char *rgbbuff, unsigned char * alpha,
                unsigned int x_pan, unsigned int y_pan,
                unsigned int x_offs, unsigned int y_offs);
 int getCurrentRes(int *x, int *y);
+void vt_setup();
 
 #ifdef FBV_SUPPORT_BMP
 int fh_bmp_id(char *name);

--- a/main.c
+++ b/main.c
@@ -26,6 +26,23 @@ static int opt_delay = 0;
 static int opt_enlarge = 0;
 static int opt_ignore_aspect = 0;
 
+static char inline_help[] =
+	"keys:\n"
+	"r		Redraw the image\n"
+	"< or ,		Previous image\n"
+	"> or .		Next image\n"
+	"a, d, w, x	Scroll the image (cursor keys also do that)\n"
+	"f		Toggle shrinking on/off\n"
+	"k		Toggle shrinking quality\n"
+	"e		Toggle enlarging on/off\n"
+	"l		Toggle fitting the image horizontally\n"
+	"t		Toggle fitting the image vertically\n"
+	"i		Toggle respecting the image aspect on/off\n"
+	"n		Rotate the image 90 degrees left\n"
+	"m		Rotate the image 90 degrees right\n"
+	"p		Disable all transformations\n"
+	"h		Help and image information\n";
+
 void setup_console(int t)
 {
 	struct termios our_termios;
@@ -210,7 +227,7 @@ int show_image(char *filename)
 	int c, ret;
 	int x_size, y_size, screen_width, screen_height;
 	int x_pan, y_pan, x_offs, y_offs, refresh = 1;
-	int delay = opt_delay, retransform = 1;
+	int delay = opt_delay, retransform = 1, noshow = 0;
 
 	int transform_shrink = opt_shrink, transform_enlarge = opt_enlarge;
 	int transform_cal = (opt_shrink == 2), transform_iaspect = opt_ignore_aspect;
@@ -302,10 +319,12 @@ identified:
 				printf("\033[H\033[J");
 				fflush(stdout);
 			}
-			if(opt_image_info)
+			if(opt_image_info) {
 				printf("fbv - The Framebuffer Viewer\n%s\n%d x %d\n", filename, x_size, y_size);
+				printf("\n%s", inline_help);
+			}
 		}
-		if(refresh)
+		if(refresh && !noshow)
 		{
 			if(i.width < screen_width)
 				x_offs = (screen_width - i.width) / 2;
@@ -429,6 +448,14 @@ identified:
 					transform_rotation -= 4;
 				retransform = 1;
 				break;
+			case 'h': case '\033':
+				if(c == '\033' && !noshow)
+					break;
+				if(!opt_image_info)
+					break;
+				retransform = 1;
+				noshow = !noshow;
+				break;
 		}
 	}// while(1)
 
@@ -480,6 +507,7 @@ void help(char *name)
 		   " n          : Rotate the image 90 degrees left\n"
 		   " m          : Rotate the image 90 degrees right\n"
 		   " p          : Disable all transformations\n"
+		   " h		: Help and image information\n"
 		   " Copyright (C) 2000 - 2004 Mateusz Golicz, Tomasz Sterna.\n"
 		   " Copyright (C) 2013 yanlin, godspeed1989@gitbub\n", name);
 }

--- a/main.c
+++ b/main.c
@@ -358,6 +358,8 @@ identified:
 		}
 
 		c = getchar();
+		if (c == -1)
+			c = 'r';
 		switch(c)
 		{
 			case EOF:
@@ -605,6 +607,8 @@ int main(int argc, char **argv)
 	signal(SIGSEGV, sighandler);
 	signal(SIGTERM, sighandler);
 	signal(SIGABRT, sighandler);
+
+	vt_setup();
 
 	if(opt_hide_cursor)
 	{

--- a/main.c
+++ b/main.c
@@ -413,6 +413,8 @@ identified:
 				transform_iaspect = 0;
 				transform_enlarge = 0;
 				transform_shrink = 0;
+				transform_widthonly = 0;
+				transform_heightonly = 0;
 				retransform = 1;
 				break;
 			case 'n':

--- a/vt.c
+++ b/vt.c
@@ -1,0 +1,47 @@
+/*
+ * vt.c
+ *
+ * vt switch handling
+ */
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <signal.h>
+#include <sys/ioctl.h>
+#include <linux/vt.h>
+
+/*
+ * signal handler: leave the virtual terminal
+ */
+void sigusr1(int s) {
+	(void) s;
+	ioctl(STDIN_FILENO, VT_RELDISP, 1);
+}
+
+/*
+ * signal handler: enter the virtual terminal
+ */
+void sigusr2(int s) {
+	(void) s;
+	ioctl(STDIN_FILENO, VT_RELDISP, VT_ACKACQ);
+}
+
+/*
+ * setup the virtual terminal for enter and leave
+ */
+void vt_setup() {
+	struct vt_mode vtmode;
+
+	signal(SIGUSR1, sigusr1);
+	signal(SIGUSR2, sigusr2);
+	siginterrupt(SIGUSR2, 1);
+
+	ioctl(STDIN_FILENO, VT_GETMODE, &vtmode);
+	vtmode.mode = VT_PROCESS;
+	vtmode.relsig = SIGUSR1;
+	vtmode.acqsig = SIGUSR2;
+	ioctl(STDIN_FILENO, VT_SETMODE, &vtmode);
+}
+


### PR DESCRIPTION
Apart some minor fixes, this merge request contains two changes:

1. with key 'h', the image is not shown; this allows to see the image info (and a short help) even when the image normally covers it

2. when the virtual terminal is switched out and then in again, fbv didn't redisplay the image; with the last commit of this merge request, it does
