### PR TITLE
zoom, INSTALLDIR, status

### DIFF
--- a/Make.conf
+++ b/Make.conf
@@ -1,6 +1,8 @@
-prefix	= /usr/local
-bindir	= /usr/local/bin
-mandir	= /usr/local/man
-infodir	= /usr/local/info
+INSTALLDIR=/usr/local
+
+prefix	= ${INSTALLDIR}
+bindir	= ${prefix}/bin
+mandir	= ${prefix}/man
+infodir	= ${prefix}/info
 
 LIBS	= -lpng -ljpeg 

--- a/fbv.1
+++ b/fbv.1
@@ -67,6 +67,7 @@ e	Toggle enlarging on/off
 l	Toggle fitting the image horizontally
 t	Toggle fitting the image vertically
 i	Toggle respecting the image aspect on/off
++, -, 0	Increase, decrease and reset zoom
 n	Rotate the image 90 degrees left
 m	Rotate the image 90 degrees right
 p	Disable all transformations

--- a/main.c
+++ b/main.c
@@ -26,6 +26,14 @@ static int opt_delay = 0;
 static int opt_enlarge = 0;
 static int opt_ignore_aspect = 0;
 
+static char inline_status[] =
+	"\nviewer status:\n"
+	"%cshrink(f)%c          %cquality shrin(k)%c    %c(e)nlarge%c\n"
+	"%chorizonta(l)_fit%c   %cver(t)ical_fit%c      %caspect(i)%c\n"
+	" zoom:%g\n";
+static char opener[2] = {' ', '['};
+static char closer[2] = {' ', ']'};
+
 static char inline_help[] =
 	"keys:\n"
 	"r		Redraw the image\n"
@@ -38,7 +46,7 @@ static char inline_help[] =
 	"l		Toggle fitting the image horizontally\n"
 	"t		Toggle fitting the image vertically\n"
 	"i		Toggle respecting the image aspect on/off\n"
-	"+, -, 0	Increase, decrease and reset zoom\n"
+	"+, -, 0		Increase, decrease and reset zoom\n"
 	"n		Rotate the image 90 degrees left\n"
 	"m		Rotate the image 90 degrees right\n"
 	"p		Disable all transformations\n"
@@ -329,6 +337,21 @@ identified:
 			}
 			if(opt_image_info) {
 				printf("fbv - The Framebuffer Viewer\n%s\n%d x %d\n", filename, x_size, y_size);
+				printf(inline_status,
+					opener[transform_shrink],
+					closer[transform_shrink],
+					opener[transform_cal],
+					closer[transform_cal],
+					opener[transform_enlarge],
+					closer[transform_enlarge],
+					opener[transform_widthonly],
+					closer[transform_widthonly],
+					opener[transform_heightonly],
+					closer[transform_heightonly],
+					opener[transform_iaspect],
+					closer[transform_iaspect],
+					1 / zoom
+				);
 				printf("\n%s", inline_help);
 			}
 		}

--- a/main.c
+++ b/main.c
@@ -38,6 +38,7 @@ static char inline_help[] =
 	"l		Toggle fitting the image horizontally\n"
 	"t		Toggle fitting the image vertically\n"
 	"i		Toggle respecting the image aspect on/off\n"
+	"+, -, 0	Increase, decrease and reset zoom\n"
 	"n		Rotate the image 90 degrees left\n"
 	"m		Rotate the image 90 degrees right\n"
 	"p		Disable all transformations\n"
@@ -234,6 +235,8 @@ int show_image(char *filename)
 	int transform_rotation = 0;
 	int transform_widthonly = opt_widthonly, transform_heightonly = opt_heightonly;
 
+	double zoom = 1;
+
 	struct image i;
 
 #ifdef FBV_SUPPORT_PNG
@@ -305,6 +308,11 @@ identified:
 
 			if(transform_rotation)
 				do_rotate(&i, transform_rotation);
+
+			if(zoom > 1)
+				do_fit_to_screen(&i, x_size / zoom, y_size / zoom, 0, 0, 0, 0);
+			if(zoom < 1)
+				do_enlarge(&i, x_size / zoom, y_size / zoom, 0, 0, 0);
 
 			if(transform_shrink)
 				do_fit_to_screen(&i, screen_width, screen_height, transform_iaspect, transform_widthonly, transform_heightonly, transform_cal);
@@ -429,6 +437,18 @@ identified:
 				transform_iaspect = !transform_iaspect;
 				retransform = 1;
 				break;
+			case '0':
+			case '+':
+			case '-':
+				transform_cal = 0;
+				transform_iaspect = 0;
+				transform_enlarge = 0;
+				transform_shrink = 0;
+				transform_widthonly = 0;
+				transform_heightonly = 0;
+				zoom = c == '0' ? 1 : c == '+' ? zoom / 1.5 : zoom * 1.5;
+				retransform = 1;
+				break;
 			case 'p':
 				transform_cal = 0;
 				transform_iaspect = 0;
@@ -436,6 +456,7 @@ identified:
 				transform_shrink = 0;
 				transform_widthonly = 0;
 				transform_heightonly = 0;
+				zoom = 1;
 				retransform = 1;
 				break;
 			case 'n':
@@ -506,10 +527,11 @@ void help(char *name)
 		   " l          : Toggle fitting the image horizontally\n"
 		   " t          : Toggle fitting the image vertically\n"
 		   " i          : Toggle respecting the image aspect on/off\n"
+		   " +, -, 0    : Increase, decrease and reset zoom\n"
 		   " n          : Rotate the image 90 degrees left\n"
 		   " m          : Rotate the image 90 degrees right\n"
 		   " p          : Disable all transformations\n"
-		   " h		: Help and image information\n"
+		   " h          : Help and image information\n"
 		   " Copyright (C) 2000 - 2004 Mateusz Golicz, Tomasz Sterna.\n"
 		   " Copyright (C) 2013 yanlin, godspeed1989@gitbub\n", name);
 }


### PR DESCRIPTION
This merge request has three commits.

The first is for arbitrarily zooming the image: + and - make the image bigger
or smaller, '0' resets its original size.

The second introduces the INSTALLDIR directory in the Makefile. This is the
standard way to tell `make` where to install.

The third is for printing the current status of the viewer on shrinking,
enlarging, fitting horizontally or vertically, keeping aspect and zooming. This
feature I found myself using often. I always forget wich key does what and what
is currently enabled. By pressing 'h' I now can see whether shrinking,
enlarging etc. are enabled or not, I see the keys to press to change them, and
when I press them I immediately see the status changing. Pressing 'h' again I
go back to see the image.
