### PR TITLE
pass the image name as shown in the help page

### DIFF
--- a/fbv.1
+++ b/fbv.1
@@ -51,6 +51,9 @@ If fitting the image to the screen, fit vertically only
 .TP
 .BR \fB--delay\fP , "\fB-s\fP \fI<delay>\fP"
 Slideshow, wait 'delay' tenths of a second before displaying each image
+.TP
+.BR "\fB-s\fP \fIimagename\fP"
+The image name as shown in the help page
 
 .SH KEYS
 .TS

--- a/fbv.1
+++ b/fbv.1
@@ -52,8 +52,9 @@ If fitting the image to the screen, fit vertically only
 .BR \fB--delay\fP , "\fB-s\fP \fI<delay>\fP"
 Slideshow, wait 'delay' tenths of a second before displaying each image
 .TP
-.BR "\fB-s\fP \fIimagename\fP"
-The image name as shown in the help page
+.BR "\fB-s\fP \fIimagenames\fP"
+The image name as shown in the help page. Defaults to the file name.
+When multiple files are passed, their names are separated by `:'
 
 .SH KEYS
 .TS

--- a/main.c
+++ b/main.c
@@ -25,6 +25,7 @@ static int opt_heightonly = 0;
 static int opt_delay = 0;
 static int opt_enlarge = 0;
 static int opt_ignore_aspect = 0;
+static char *imagename = NULL;
 
 static char inline_status[] =
 	"\nviewer status:\n"
@@ -336,7 +337,9 @@ identified:
 				fflush(stdout);
 			}
 			if(opt_image_info) {
-				printf("fbv - The Framebuffer Viewer\n%s\n%d x %d\n", filename, x_size, y_size);
+				printf("fbv - The Framebuffer Viewer\n");
+				printf("%s\n", imagename ? imagename : filename);
+				printf("%d x %d\n", x_size, y_size);
 				printf(inline_status,
 					opener[transform_shrink],
 					closer[transform_shrink],
@@ -539,6 +542,7 @@ void help(char *name)
 		   "  -t, --heightonly    Fit the image vertically\n"
 		   "  -r, --ignore-aspect Ignore the image aspect while resizing\n"
 		   "  -s <delay>, --delay <d>  Slideshow, 'delay' is the slideshow delay in tenths of seconds.\n\n"
+		   "  -n imagename        Image name shown in help"
 		   "Input keys:\n"
 		   " r          : Redraw the image\n"
 		   " < or ,     : Previous image\n"
@@ -586,6 +590,7 @@ int main(int argc, char **argv)
 		{"widthonly",     no_argument,  0, 'l'},
 		{"heightonly",    no_argument,  0, 't'},
 		{"ignore-aspect", no_argument,  0, 'r'},
+		{"imagename",     required_argument, 0, 'n'},
 		{0, 0, 0, 0}
 	};
 	int c, i;
@@ -597,7 +602,7 @@ int main(int argc, char **argv)
 		return 1;
 	}
 
-	while((c = getopt_long_only(argc, argv, "hcauifks:eltr", long_options, NULL)) != EOF)
+	while((c = getopt_long_only(argc, argv, "hn:cauifks:eltr", long_options, NULL)) != EOF)
 	{
 		switch(c)
 		{
@@ -612,6 +617,9 @@ int main(int argc, char **argv)
 				break;
 			case 'u':
 				opt_hide_cursor = 0;
+				break;
+			case 'n':
+				imagename = optarg;
 				break;
 			case 'h':
 				help(argv[0]);

--- a/main.c
+++ b/main.c
@@ -542,7 +542,7 @@ void help(char *name)
 		   "  -t, --heightonly    Fit the image vertically\n"
 		   "  -r, --ignore-aspect Ignore the image aspect while resizing\n"
 		   "  -s <delay>, --delay <d>  Slideshow, 'delay' is the slideshow delay in tenths of seconds.\n\n"
-		   "  -n imagename        Image name shown in help"
+		   "  -n imagename(s)     Image name(s) shown in help"
 		   "Input keys:\n"
 		   " r          : Redraw the image\n"
 		   " < or ,     : Previous image\n"
@@ -594,6 +594,8 @@ int main(int argc, char **argv)
 		{0, 0, 0, 0}
 	};
 	int c, i;
+	char *nameopts = NULL;
+	char **namestarts = NULL;
 
 	if(argc < 2)
 	{
@@ -619,7 +621,7 @@ int main(int argc, char **argv)
 				opt_hide_cursor = 0;
 				break;
 			case 'n':
-				imagename = optarg;
+				nameopts = optarg;
 				break;
 			case 'h':
 				help(argv[0]);
@@ -654,6 +656,18 @@ int main(int argc, char **argv)
 		return 1;
 	}
 
+	namestarts = (char **) malloc((argc - optind) * sizeof(char *));
+	for (i = 0; i < argc - optind; i++) {
+		namestarts[i] = nameopts;
+		if (nameopts == NULL)
+			continue;
+		nameopts = strchr(nameopts, ':');
+		if (nameopts == NULL)
+			continue;
+		*nameopts = '\0';
+		nameopts++;
+	}
+
 	signal(SIGHUP, sighandler);
 	signal(SIGINT, sighandler);
 	signal(SIGQUIT, sighandler);
@@ -674,6 +688,7 @@ int main(int argc, char **argv)
 	i = optind;
 	while(argv[i])
 	{
+		imagename = namestarts[i - optind];
 		int r = show_image(argv[i]);
 		if(r == 0)
 			break;


### PR DESCRIPTION
These two commits add a new option -n name, or --imagename name. This is the file name as shown in the help page. Multiple image names are separated by ':'.

This is useful when the image that is displayed is the result of a conversion or a download. For example, to show a certain type of image on the virtual console I can set up a script that first converts the image to a jpeg or png temp file and displays it with fbv. Showing the name of the temp file on the help screen is not what the user expects. Rather, it should be the name of the original file.

The same happens when the image is downloaded: rather than showing the name of the temp file, the help page should rather show the url of the image. Or the alt field (in case of html), maybe.

The -n/--imagename option is for example present in feh as the --info argument. Other image viewers allow to set the X11 title, for example gwenview has the --title option. This --imagename option has the same role in fbv.
