### PR TITLE
fix man page + split the image names only on multiple image names

### DIFF
--- a/fbv.1
+++ b/fbv.1
@@ -52,7 +52,7 @@ If fitting the image to the screen, fit vertically only
 .BR \fB--delay\fP , "\fB-s\fP \fI<delay>\fP"
 Slideshow, wait 'delay' tenths of a second before displaying each image
 .TP
-.BR "\fB-s\fP \fIimagenames\fP"
+.BR "\fB-n\fP \fIimagename\fP"
 The image name as shown in the help page. Defaults to the file name.
 When multiple files are passed, their names are separated by `:'
 

--- a/fbv.1
+++ b/fbv.1
@@ -54,7 +54,7 @@ Slideshow, wait 'delay' tenths of a second before displaying each image
 .TP
 .BR "\fB-n\fP \fIimagename\fP"
 The image name as shown in the help page. Defaults to the file name.
-When multiple files are passed, their names are separated by `:'
+When multiple files are passed, their names are separated by `^'
 
 .SH KEYS
 .TS

--- a/main.c
+++ b/main.c
@@ -662,7 +662,7 @@ int main(int argc, char **argv)
 			namestarts[i] = nameopts;
 			if (nameopts == NULL)
 				continue;
-			nameopts = strchr(nameopts, ':');
+			nameopts = strchr(nameopts, '^');
 			if (nameopts == NULL)
 				continue;
 			*nameopts = '\0';

--- a/main.c
+++ b/main.c
@@ -656,16 +656,18 @@ int main(int argc, char **argv)
 		return 1;
 	}
 
-	namestarts = (char **) malloc((argc - optind) * sizeof(char *));
-	for (i = 0; i < argc - optind; i++) {
-		namestarts[i] = nameopts;
-		if (nameopts == NULL)
-			continue;
-		nameopts = strchr(nameopts, ':');
-		if (nameopts == NULL)
-			continue;
-		*nameopts = '\0';
-		nameopts++;
+	if (argc - optind > 1) {
+		namestarts = (char **) malloc((argc - optind) * sizeof(char *));
+		for (i = 0; i < argc - optind; i++) {
+			namestarts[i] = nameopts;
+			if (nameopts == NULL)
+				continue;
+			nameopts = strchr(nameopts, ':');
+			if (nameopts == NULL)
+				continue;
+			*nameopts = '\0';
+			nameopts++;
+		}
 	}
 
 	signal(SIGHUP, sighandler);
@@ -688,7 +690,8 @@ int main(int argc, char **argv)
 	i = optind;
 	while(argv[i])
 	{
-		imagename = namestarts[i - optind];
+		imagename = (argc - optind == 1) ?
+			 nameopts : namestarts[i - optind];
 		int r = show_image(argv[i]);
 		if(r == 0)
 			break;


### PR DESCRIPTION
The -n option (image names) is useful when the image that is shown comes from somewhere else - it is downloaded or converted to a temporary file. The name   of the temporary file is not meaningful to the user, its source is. When the file comes from the Web, this is the url of the image. I made a bad decision when I chose ':' for the image name separator, as this character is in every   url.

Every character may create similar problems in other contexts. A simpler solution is just not to split the image names when only one image is passed. This is the most common case, especially when the image comes from downloading or converting.
