### PR TITLE
Apply patches from buildroot repos

### DIFF
--- a/configure
+++ b/configure
@@ -77,6 +77,7 @@ while true ; do
 	esac
 done
 
+[ -z "$CC" ] && CC=cc
 [ -z "$prefix" ] && prefix="/usr/local"
 [ -z "$bindir" ] && bindir="${prefix}/bin"
 [ -z "$mandir" ] && mandir="${prefix}/man"
@@ -101,7 +102,7 @@ EOF
 echo -n "checking for libjpeg presence... "
 if [ "$jpeg" != "disabled" ]; then
 jpeg="no"
-cc 2>>./config.log >>./config.log -o \$\$~test \$\$~test.c -ljpeg $libs
+$CC 2>>./config.log >>./config.log -o \$\$~test \$\$~test.c -ljpeg $libs
 if [ -e \$\$~test ]; then
 	libs="-ljpeg $libs" ; jpeg="yes"
 fi
@@ -112,7 +113,7 @@ echo "libjpeg: $jpeg" >> ./config.log
 echo -n "checking for libpng presence... "
 if [ "$png" != "disabled" ]; then
 png="no"
-cc 2>>./config.log >>./config.log -o \$\$~test \$\$~test.c -lpng $libs
+$CC 2>>./config.log >>./config.log -o \$\$~test \$\$~test.c -lpng $libs
 if [ -e \$\$~test ]; then
 	libs="-lpng $libs" ; png="yes"
 fi

--- a/fb_display.c
+++ b/fb_display.c
@@ -336,6 +336,16 @@ void* convertRGB2FB(int fh, unsigned char *rgbbuff, unsigned long count, int bpp
 		fbbuff = (void *) s_fbbuff;
 		break;
 	case 24:
+	    *cpp = 3;
+	    c_fbbuff = (unsigned char *) malloc(count * 3 * sizeof(unsigned char));
+	    for(i = 0; i < (3 * count); i += 3) {
+		/* Big endian framebuffer. */
+		c_fbbuff[i] = rgbbuff[i+2];
+		c_fbbuff[i+1] = rgbbuff[i+1];
+		c_fbbuff[i+2] = rgbbuff[i];
+	    }
+	    fbbuff = (void *) c_fbbuff;
+	    break;
 	case 32:
 		*cpp = 4;
 		i_fbbuff = (unsigned int *) malloc(count * sizeof(unsigned int));


### PR DESCRIPTION
The goal is to use this version of fbv in buildroot in future.
However, before switching, I want to add some available patches:
https://github.com/buildroot/buildroot/tree/master/package/fbv

* 0002-cross.patch
    * Patch applied in first commit of this PR
* 0003-fix-24bpp-support-on-big-endian.patch
    * Patch applied in second commit of this PR
* 0004-fix-bgr555.patch
   * Not applied, as I don't understand the reason yet. Currently, I didn't discover any problems without this patch.
* 0005-giflib.patch
    * Not applied, as gif support was removed in this repo
* 0006-include.patch
    * Not applied, as I don't understand the reason for this patch. fbv compiles with no problems without this patch
* 0007-libpng15.patch
    * Not applied, as changes are already included in current fbv version
