### PR TITLE
Add additional parameter to display image fullscren

### DIFF
--- a/main.c
+++ b/main.c
@@ -23,6 +23,7 @@ static int opt_image_info = 1;
 static int opt_shrink = 0;
 static int opt_widthonly = 0;
 static int opt_heightonly = 0;
+static int opt_fullscreen = 0;
 static int opt_delay = 0;
 static int opt_enlarge = 0;
 static int opt_ignore_aspect = 0;
@@ -308,6 +309,29 @@ identified:
 	if(getCurrentRes(&screen_width, &screen_height))
 		goto error;
 	i.do_free = 0;
+
+	if (opt_fullscreen)
+	{
+		transform_shrink = 1;
+		transform_enlarge = 1;
+
+		// Check if screen aspect ratio is larger than image aspect ratio
+		// screen_width/screen_height > x_size/y_size
+		if (screen_width*y_size > x_size*screen_height)
+		{
+			 transform_widthonly = 1;
+			 transform_heightonly = 0;
+		}
+		else
+		{
+			 transform_widthonly = 0;
+			 transform_heightonly = 1;
+		}
+	}
+
+
+
+
 	while(1)
 	{
 		if(retransform)
@@ -548,6 +572,7 @@ void help(char *name)
 		   "  -e, --enlarge       Enlarge the image to fit the whole screen if necessary\n"
 		   "  -l, --widthonly     Fit the image horizontally\n"
 		   "  -t, --heightonly    Fit the image vertically\n"
+		   "  -x, --fullscreen    Show image by covering the whole screen. Parts might be out of screen area\n"
 		   "  -r, --ignore-aspect Ignore the image aspect while resizing\n"
 		   "  -s <delay>, --delay <d>  Slideshow, 'delay' is the slideshow delay in tenths of seconds.\n\n"
 		   "  -n imagename(s)     Image name(s) shown in help"
@@ -597,6 +622,7 @@ int main(int argc, char **argv)
 		{"enlarge",       no_argument,  0, 'e'},
 		{"widthonly",     no_argument,  0, 'l'},
 		{"heightonly",    no_argument,  0, 't'},
+		{"fullscreen",    no_argument,  0, 'x'},
 		{"ignore-aspect", no_argument,  0, 'r'},
 		{"imagename",     required_argument, 0, 'n'},
 		{0, 0, 0, 0}
@@ -612,7 +638,7 @@ int main(int argc, char **argv)
 		return 1;
 	}
 
-	while((c = getopt_long_only(argc, argv, "hn:cauifks:eltr", long_options, NULL)) != EOF)
+	while((c = getopt_long_only(argc, argv, "hn:cauifks:eltxr", long_options, NULL)) != EOF)
 	{
 		switch(c)
 		{
@@ -651,6 +677,9 @@ int main(int argc, char **argv)
 				break;
 			case 't':
 				opt_heightonly = 1;
+				break;
+			case 'x':
+				opt_fullscreen = 1;
 				break;
 			case 'r':
 				opt_ignore_aspect = 1;


### PR DESCRIPTION
Using the command line parameter "-x" or "--fullscreen, the image
covers the entire screen. The behaviour is identical to "--shrink",
"--enlarge" in combination with "--widthonly" or "--heightonly"
depending on the aspect ration of screen and image.